### PR TITLE
Exception when checking for symlinks in initialize_shared_storage

### DIFF
--- a/drbdlinks
+++ b/drbdlinks
@@ -551,7 +551,7 @@ elif mode == 'initialize_shared_storage':
 		print 'Copying "%s" to "%s"' % ( linkLocal, linkDest )
 		os.system('cp -ar "%s" "%s"' % ( linkLocal, linkDest ))
 
-		fp = os.popen('find "%s" -type l -lname "[^/].*" -print0', linkLocal)
+		fp = os.popen('find "%s" -type l -lname "[^/].*" -print0' % linkLocal)
 		relative_symlinks += fp.read().split('\0')
 		fp.close()
 


### PR DESCRIPTION
hi,

i think i found a problem when using drbd initialize_shared_storage

the arguments to os.popen() seems to be wrong. This small change should fix the problem

thanks,
flavio
