### PR TITLE
do not add empty strings when checking for relative symlinks

### DIFF
--- a/drbdlinks
+++ b/drbdlinks
@@ -610,7 +610,7 @@ elif mode == 'initialize_shared_storage':
         os.system('cp -ar "%s" "%s"' % (linkLocal, linkDest))
 
         fp = os.popen('find "%s" -type l -lname "[^/].*" -print0' % linkLocal)
-        relative_symlinks += fp.read().split('\0')
+        relative_symlinks += [ l for l in fp.read().split('\0') if l ]
         fp.close()
 
     if relative_symlinks:


### PR DESCRIPTION
hi,

i think i found a problem when the check for symlinks in initialize_shared_storage is done

if no symlinks are found, an empty string is returned resulting in a value like [""] for the variable relative_symlinks, which evaluates to true in the test immediately after, raising an exception in the print statement

this should fix the problem

thanks,
flavio
